### PR TITLE
dfuzzer.conf: update systemd suppressions

### DIFF
--- a/.github/workflows/run-tests.sh
+++ b/.github/workflows/run-tests.sh
@@ -2,6 +2,19 @@
 
 set -ex
 
+sudo sed -i -e '/^#\s*deb-src.*\smain\s\+restricted/s/^#//' /etc/apt/sources.list
+sudo apt-get update
+sudo apt-get build-dep -y systemd
+sudo apt-get install -y python3-jinja2
+
+git clone https://github.com/systemd/systemd
+pushd systemd
+meson build
+ninja -C ./build
+sudo ninja -C ./build install
+sudo systemctl daemon-reexec
+popd
+
 dfuzzer=("dfuzzer")
 if [[ "$TYPE" == valgrind ]]; then
         dfuzzer=("valgrind" "--leak-check=full" "--show-leak-kinds=definite" "--errors-for-leak-kinds=definite" "--error-exitcode=42" "dfuzzer")

--- a/.github/workflows/run-tests.sh
+++ b/.github/workflows/run-tests.sh
@@ -63,7 +63,11 @@ grep "SKIP" "$log_out" && false
 # Test as an unprivileged user (short options)
 "${dfuzzer[@]}" -v -n org.freedesktop.systemd1
 # Test as root (long options + duplicate options)
+set +e
 sudo "${dfuzzer[@]}" --verbose --bus this.should.be.ignored --bus org.freedesktop.systemd1
+systemctl daemon-reload
+journalctl --no-pager -e
+set -e
 # Test logdir
 mkdir dfuzzer-logs
 "${dfuzzer[@]}" --log-dir dfuzzer-logs -v -n org.freedesktop.systemd1

--- a/src/dfuzzer.conf
+++ b/src/dfuzzer.conf
@@ -31,10 +31,8 @@ Halt destructive
 KExec destructive
 PowerOff destructive
 Reboot destructive
-Ref destructive
 Reexecute kind of resets systemd
 Reload kind of resets systemd
-Unref destructive
 
 [org.freedesktop.timedate1]
 SetLocalRTC destructive method breaking the RTC and system time

--- a/src/dfuzzer.conf
+++ b/src/dfuzzer.conf
@@ -31,8 +31,10 @@ Halt destructive
 KExec destructive
 PowerOff destructive
 Reboot destructive
+Ref destructive
 Reexecute kind of resets systemd
 Reload kind of resets systemd
+Unref destructive
 
 [org.freedesktop.timedate1]
 SetLocalRTC destructive method breaking the RTC and system time

--- a/src/dfuzzer.conf
+++ b/src/dfuzzer.conf
@@ -31,9 +31,8 @@ Halt destructive
 KExec destructive
 PowerOff destructive
 Reboot destructive
-Ref destructive
-Thaw destructive
-Unref destructive
+Reexecute kind of resets systemd
+Reload kind of resets systemd
 
 [org.freedesktop.timedate1]
 SetLocalRTC destructive method breaking the RTC and system time


### PR DESCRIPTION
Ref, Thaw and Unref don't seem to be destructive.

Reexecute and Reload aren't destructive but they
kind of reset systemd and potential overflows and stuff
like that that has to be accumulated to be triggered
are reset as well. They aren't valgrind-friendly either.