### PR TITLE
ci: send dfuzzer to Coverity Scan

### DIFF
--- a/.github/workflows/coverity.sh
+++ b/.github/workflows/coverity.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+set -eux
+
+COVERITY_SCAN_TOOL_BASE="/tmp/coverity-scan-analysis"
+COVERITY_SCAN_PROJECT_NAME="dfuzzer"
+
+function coverity_install_script {
+    local platform tool_url tool_archive
+
+    platform=$(uname)
+    tool_url="https://scan.coverity.com/download/${platform}"
+    tool_archive="/tmp/cov-analysis-${platform}.tgz"
+
+    set +x # this is supposed to hide COVERITY_SCAN_TOKEN
+    echo -e "\033[33;1mDownloading Coverity Scan Analysis Tool...\033[0m"
+    wget -nv -O "$tool_archive" "$tool_url" --post-data "project=$COVERITY_SCAN_PROJECT_NAME&token=$COVERITY_SCAN_TOKEN"
+    set -x
+
+    mkdir -p "$COVERITY_SCAN_TOOL_BASE"
+    pushd "$COVERITY_SCAN_TOOL_BASE"
+    tar xzf "$tool_archive"
+    popd
+}
+
+function run_coverity {
+    local results_dir tool_dir results_archive sha author_email response status_code
+
+    results_dir="cov-int"
+    tool_dir=$(find "$COVERITY_SCAN_TOOL_BASE" -type d -name 'cov-analysis*')
+    results_archive="analysis-results.tgz"
+    sha=$(git rev-parse --short HEAD)
+    author_email=$(git log -1 --pretty="%aE")
+
+    meson -Ddfuzzer-test-server=true build
+    COVERITY_UNSUPPORTED=1 "$tool_dir/bin/cov-build" --dir "$results_dir" sh -c "ninja -C ./build -v"
+    "$tool_dir/bin/cov-import-scm" --dir "$results_dir" --scm git --log "$results_dir/scm_log.txt"
+
+    tar czf "$results_archive" "$results_dir"
+
+    set +x # this is supposed to hide COVERITY_SCAN_TOKEN
+    echo -e "\033[33;1mUploading Coverity Scan Analysis results...\033[0m"
+    response=$(curl \
+               --silent --write-out "\n%{http_code}\n" \
+               --form project="$COVERITY_SCAN_PROJECT_NAME" \
+               --form token="$COVERITY_SCAN_TOKEN" \
+               --form email="$author_email" \
+               --form file="@$results_archive" \
+               --form version="$sha" \
+               --form description="Daily build" \
+               https://scan.coverity.com/builds)
+    printf "\033[33;1mThe response is\033[0m\n%s\n" "$response"
+    status_code=$(echo "$response" | sed -n '$p')
+    if [ "$status_code" != "200" ]; then
+        echo -e "\033[33;1mCoverity Scan upload failed: $(echo "$response" | sed '$d').\033[0m"
+        return 1
+    fi
+    set -x
+}
+
+coverity_install_script
+run_coverity

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,28 @@
+---
+name: Coverity
+
+on:
+  schedule:
+    # Run Coverity daily at midnight
+    - cron:  '0 0 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    if: github.repository == 'dbus-fuzzer/dfuzzer'
+    env:
+      COVERITY_SCAN_TOKEN: "${{ secrets.COVERITY_SCAN_TOKEN }}"
+    steps:
+      - name: Repository checkout
+        uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: |
+          sudo apt -y update
+          sudo apt -y install gcc libglib2.0-dev meson
+
+      - name: Run Coverity
+        run: .github/workflows/coverity.sh

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ dfuzzer
 =======
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/matusmarhefka/dfuzzer.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/matusmarhefka/dfuzzer/alerts/)
 [![Coverage Status](https://coveralls.io/repos/github/matusmarhefka/dfuzzer/badge.svg)](https://coveralls.io/github/matusmarhefka/dfuzzer)
+[![Coverity Scan Status](https://scan.coverity.com/projects/24889/badge.svg)](https://scan.coverity.com/projects/dfuzzer)
 
 dfuzzer is a D-Bus fuzzer, a tool for fuzz testing processes communicating
 through D-Bus. It can be used to test processes connected to both, the session


### PR DESCRIPTION
It was tested in https://github.com/evverx/dfuzzer/runs/6485173495?check_suite_focus=true and it seems to be working as far as I can see