### PR TITLE
fuzz: generate an empty array on the first iteration

### DIFF
--- a/src/fuzz.c
+++ b/src/fuzz.c
@@ -266,7 +266,7 @@ GVariant *df_generate_random_from_signature(const char *signature, guint64 itera
                         array_signature = g_variant_type_dup_string(array_type);
 
                         /* Create a pseudo-randomly sized array */
-                        for (int i = 0; i < rand() % 10; i++) {
+                        for (size_t i = 0; i < df_rand_array_size(iteration); i++) {
                                 GVariant *array_item = NULL;
 
                                 array_item = df_generate_random_from_signature(array_signature, iteration);

--- a/src/rand.c
+++ b/src/rand.c
@@ -81,6 +81,16 @@ int df_rand_load_external_dictionary(const char *filename)
 
         return 0;
 }
+
+size_t df_rand_array_size(guint64 iteration)
+{
+        /* Generate an empty array on the first iteration */
+        if (iteration == 0)
+                return 0;
+
+        return rand() % 10;
+}
+
 /**
  * @return Generated pseudo-random 8-bit unsigned integer value
  */

--- a/src/rand.h
+++ b/src/rand.h
@@ -46,6 +46,8 @@ struct external_dictionary {
 void df_rand_init();
 int df_rand_load_external_dictionary(const char *filename);
 
+size_t df_rand_array_size(guint64 iteration);
+
 /**
  * @return Generated pseudo-random 8-bit unsigned integer value
  */


### PR DESCRIPTION
if the signature contains an array.