### PR TITLE
update systemd suppressions

### DIFF
--- a/.github/workflows/run-tests.sh
+++ b/.github/workflows/run-tests.sh
@@ -11,6 +11,10 @@ fi
 # shellcheck disable=SC1004
 sudo sed -i '/\[org.freedesktop.systemd1\]/a \
 org.freedesktop.systemd1.Manager:Reexecute Fixed by https://github.com/systemd/systemd/pull/23328 \
+org.freedesktop.systemd1.Manager:RefUnit \
+org.freedesktop.systemd1.Manager:UnrefUnit \
+Ref \
+Unref \
 ' /etc/dfuzzer.conf
 
 sudo systemctl daemon-reload

--- a/src/dfuzzer.conf
+++ b/src/dfuzzer.conf
@@ -31,12 +31,7 @@ org.freedesktop.systemd1.Manager:Halt destructive
 org.freedesktop.systemd1.Manager:KExec destructive
 org.freedesktop.systemd1.Manager:PowerOff destructive
 org.freedesktop.systemd1.Manager:Reboot destructive
-org.freedesktop.systemd1.Manager:RefUnit destructive
-org.freedesktop.systemd1.Manager:UnrefUnit destructive
 Freeze destructive
-Ref destructive
-Thaw destructive
-Unref destructive
 
 [org.freedesktop.timedate1]
 SetLocalRTC destructive method breaking the RTC and system time


### PR DESCRIPTION
Ref*, Unref* and Thaw* aren't destructive. They just trigger various issues in systemd. All those issues have been fixed upstream so it should be safe to unblock them.