### PR TITLE
dfuzzer: bail out on any D-Bus error while traversing the tree

### DIFF
--- a/src/bus.c
+++ b/src/bus.c
@@ -52,8 +52,7 @@ GVariant *df_bus_call_full(GDBusProxy *proxy, const char *method, GVariant *valu
                 if (ret_error)
                         *ret_error = TAKE_PTR(error);
                 else {
-                        g_dbus_error_strip_remote_error(error);
-                        df_fail("Error while calling method '%s': %s.\n", method, error->message);
+                        df_fail("Error while calling method '%s': %s\n", method, error->message);
                         df_error("Error in g_dbus_proxy_call_sync()", error);
                 }
 

--- a/src/dfuzzer.c
+++ b/src/dfuzzer.c
@@ -355,24 +355,10 @@ int df_traverse_node(GDBusConnection *dcon, const char *root_node)
         if (!dproxy)
                 return DF_BUS_ERROR;
 
-        response = df_bus_call_full(dproxy, intro_method, NULL, G_DBUS_CALL_FLAGS_NONE, &error);
-        if (!response) {
-                _cleanup_(g_freep) gchar *dbus_error = NULL;
-                // D-Bus exceptions
-                if ((dbus_error = g_dbus_error_get_remote_error(error)) != NULL) {
-                        // if process does not respond
-                        if (g_str_equal(dbus_error, "org.freedesktop.DBus.Error.NoReply"))
-                                return DF_BUS_FAIL;
-                        if (g_str_equal(dbus_error, "org.freedesktop.DBus.Error.Timeout"))
-                                return DF_BUS_FAIL;
-                        return DF_BUS_OK;
-                } else {
-                        g_dbus_error_strip_remote_error(error);
-                        df_fail("Error: %s.\n", error->message);
-                        df_error("Error in g_dbus_proxy_call_sync()", error);
-                        return DF_BUS_ERROR;
-                }
-        }
+        response = df_bus_call(dproxy, intro_method, NULL, G_DBUS_CALL_FLAGS_NONE);
+        if (!response)
+                return DF_BUS_ERROR;
+
         g_variant_get(response, "(s)", &introspection_xml);
         if (!introspection_xml) {
                 df_fail("Error: Unable to get introspection data from GVariant.\n");

--- a/src/dfuzzer.h
+++ b/src/dfuzzer.h
@@ -78,16 +78,6 @@ int df_process_bus(GBusType bus_type);
 int df_list_bus_names(GDBusConnection *dcon);
 
 /**
- * @function Traverses through all objects of bus name target_proc.name
- * and is looking for object path target_proc.obj_path
- * @param dcon D-Bus connection structure
- * @param root_node Starting object path (all nodes from this object path
- * will be traversed)
- * @return 1 when obj. path target_proc.obj_path is found on bus, 0 otherwise
- */
-int df_is_object_on_bus(GDBusConnection *dcon, const char *root_node);
-
-/**
  * @function Traverses through all interfaces and objects of bus
  * name target_proc.name and for each interface it calls df_fuzz()
  * to fuzz test all its methods.


### PR DESCRIPTION
Also, simplify the D-Bus error handling by always dumping the remote
error code.

Resolves: #98