### PR TITLE
Use GLib helpers instead of our own where possible

### DIFF
--- a/src/bus.c
+++ b/src/bus.c
@@ -22,7 +22,7 @@ GDBusProxy *df_bus_new_full(GDBusConnection *dcon, const char *name, const char 
                         &error);
         if (!dproxy) {
                 if (ret_error)
-                        *ret_error = TAKE_PTR(error);
+                        *ret_error = g_steal_pointer(&error);
                 else {
                         df_fail("Error: Unable to create proxy for bus name '%s'.\n", name);
                         df_error("Error in g_dbus_proxy_new_sync() on creating proxy", error);
@@ -50,7 +50,7 @@ GVariant *df_bus_call_full(GDBusProxy *proxy, const char *method, GVariant *valu
                         &error);
         if (!response) {
                 if (ret_error)
-                        *ret_error = TAKE_PTR(error);
+                        *ret_error = g_steal_pointer(&error);
                 else {
                         df_fail("Error while calling method '%s': %s\n", method, error->message);
                         df_error("Error in g_dbus_proxy_call_sync()", error);

--- a/src/bus.c
+++ b/src/bus.c
@@ -8,7 +8,7 @@
 GDBusProxy *df_bus_new_full(GDBusConnection *dcon, const char *name, const char *object,
                        const char *interface, GDBusProxyFlags flags, GError **ret_error)
 {
-        _cleanup_(g_error_freep) GError *error = NULL;
+        g_autoptr(GError) error = NULL;
         GDBusProxy *dproxy = NULL;
 
         dproxy = g_dbus_proxy_new_sync(
@@ -37,7 +37,7 @@ GDBusProxy *df_bus_new_full(GDBusConnection *dcon, const char *name, const char 
 GVariant *df_bus_call_full(GDBusProxy *proxy, const char *method, GVariant *value,
                            GDBusCallFlags flags, GError **ret_error)
 {
-        _cleanup_(g_error_freep) GError *error = NULL;
+        g_autoptr(GError) error = NULL;
         GVariant *response = NULL;
 
         response = g_dbus_proxy_call_sync(

--- a/src/dfuzzer-test-server.c
+++ b/src/dfuzzer-test-server.c
@@ -206,7 +206,7 @@ static gboolean handle_set_property(
                 str = g_variant_dup_string(value, NULL);
                 if (str) {
                         g_free(prop_write_only);
-                        prop_write_only = TAKE_PTR(str);
+                        prop_write_only = g_steal_pointer(&str);
                         return TRUE;
                 }
         } else if (g_str_equal(property_name, "crash_on_write"))

--- a/src/dfuzzer-test-server.c
+++ b/src/dfuzzer-test-server.c
@@ -120,7 +120,7 @@ static void handle_method_call(
                 const gchar *method_name, GVariant *parameters,
                 GDBusMethodInvocation *invocation, gpointer user_data)
 {
-        g_autofree gchar *response = NULL;
+        g_autoptr(gchar) response = NULL;
 
         g_printf("->[handle_method_call] %s\n", method_name);
 
@@ -196,13 +196,13 @@ static gboolean handle_set_property(
                 const gchar *interface_name, const gchar *property_name, GVariant *value,
                 GError **error, gpointer user_data)
 {
-        g_autofree gchar *serialized_value = NULL;
+        g_autoptr(gchar) serialized_value = NULL;
 
         serialized_value = g_variant_print(value, TRUE);
         g_printf("->[handle_set_property] %s -> %s\n", property_name, serialized_value);
 
         if (g_str_equal(property_name, "write_only")) {
-                g_autofree gchar *str = NULL;
+                g_autoptr(gchar) str = NULL;
                 str = g_variant_dup_string(value, NULL);
                 if (str) {
                         g_free(prop_write_only);

--- a/src/dfuzzer.c
+++ b/src/dfuzzer.c
@@ -412,7 +412,7 @@ int df_fuzz(GDBusConnection *dcon, const char *name, const char *object, const c
 
         /* Test properties */
         STRV_FOREACH_COND(p, interface_info->properties, !df_skip_properties) {
-                _cleanup_(df_dbus_property_cleanup) struct df_dbus_property dbus_property = {0,};
+                g_auto(df_dbus_property_t) dbus_property = {0,};
 
                 /* Test only a specific property if set */
                 if (df_test_property && !g_str_equal(df_test_property, p->name))
@@ -474,7 +474,7 @@ int df_fuzz(GDBusConnection *dcon, const char *name, const char *object, const c
 
         /* Test methods */
         STRV_FOREACH_COND(m, interface_info->methods, !df_skip_methods) {
-                _cleanup_(df_dbus_method_cleanup) struct df_dbus_method dbus_method = {0,};
+                g_auto(df_dbus_method_t) dbus_method = {0,};
                 char *description;
 
                 /* Test only a specific method if set */
@@ -659,7 +659,7 @@ void df_print_process_info(int pid)
 {
         char proc_path[15 + DECIMAL_STR_MAX(int)]; // "/proc/(int)/[exe|cmdline]"
         char name[PATH_MAX + 1];
-        _cleanup_close_ int fd = -1;
+        g_auto(fd_t) fd = -1;
         int ret;
 
         sprintf(proc_path, "/proc/%d/exe", pid);

--- a/src/dfuzzer.c
+++ b/src/dfuzzer.c
@@ -1043,7 +1043,7 @@ int df_load_suppressions(void)
                 /* Extract method name */
                 p = strrchr(suppression, ':');
                 if (!p)
-                        suppressions[i]->method = TAKE_PTR(suppression);
+                        suppressions[i]->method = g_steal_pointer(&suppression);
                 else {
                         suppressions[i]->method = strdup(p + 1);
                         *p = 0;
@@ -1079,7 +1079,7 @@ int df_load_suppressions(void)
                                 return df_oom();
                 }
 
-                suppressions[i]->description = TAKE_PTR(description);
+                suppressions[i]->description = g_steal_pointer(&description);
                 df_verbose("Loaded suppression for method: %s:%s:%s (%s)\n",
                            isempty(suppressions[i]->object) ? "*" : suppressions[i]->object,
                            isempty(suppressions[i]->interface) ? "*" : suppressions[i]->interface,

--- a/src/dfuzzer.c
+++ b/src/dfuzzer.c
@@ -146,8 +146,8 @@ cleanup:
 
 int df_process_bus(GBusType bus_type)
 {
-        _cleanup_(g_dbus_connection_unrefp) GDBusConnection *dcon = NULL;
-        _cleanup_(g_error_freep) GError *error = NULL;
+        g_autoptr(GDBusConnection) dcon = NULL;
+        g_autoptr(GError) error = NULL;
 
         switch (bus_type) {
         case G_BUS_TYPE_SESSION:
@@ -208,9 +208,9 @@ int df_process_bus(GBusType bus_type)
  */
 int df_list_bus_names(GDBusConnection *dcon)
 {
-        _cleanup_(g_dbus_proxy_unrefp) GDBusProxy *proxy = NULL;
-        _cleanup_(g_variant_iter_freep) GVariantIter *iter = NULL;
-        _cleanup_(g_variant_unrefp) GVariant *response = NULL;
+        g_autoptr(GDBusProxy) proxy = NULL;
+        g_autoptr(GVariantIter) iter = NULL;
+        g_autoptr(GVariant) response = NULL;
         char *str;
 
         proxy = df_bus_new(dcon,
@@ -261,12 +261,12 @@ int df_traverse_node(GDBusConnection *dcon, const char *root_node)
 {
         char *intro_iface = "org.freedesktop.DBus.Introspectable";
         char *intro_method = "Introspect";
-        _cleanup_(g_variant_unrefp) GVariant *response = NULL;
-        _cleanup_(g_dbus_proxy_unrefp) GDBusProxy *dproxy = NULL;
-        _cleanup_(g_freep) gchar *introspection_xml = NULL;
-        _cleanup_(g_error_freep) GError *error = NULL;
+        g_autoptr(GVariant) response = NULL;
+        g_autoptr(GDBusProxy) dproxy = NULL;
+        g_autoptr(gchar) introspection_xml = NULL;
+        g_autoptr(GError) error = NULL;
         /** Information about nodes in a remote object hierarchy. */
-        _cleanup_(g_dbus_node_info_unrefp) GDBusNodeInfo *node_data = NULL;
+        g_autoptr(GDBusNodeInfo) node_data = NULL;
         /** Return values */
         int rd = 0;          // return value from df_fuzz()
         int rt = 0;          // return value from recursive transition
@@ -321,7 +321,7 @@ int df_traverse_node(GDBusConnection *dcon, const char *root_node)
 
         // go through all nodes
         STRV_FOREACH(node, node_data->nodes) {
-                _cleanup_free_ char *object = NULL;
+                g_autoptr(char) object = NULL;
                 // create next object path
                 object = strjoin(root_node, strlen(root_node) == 1 ? "" : "/", node->path);
                 if (object == NULL) {
@@ -377,8 +377,8 @@ static int df_path_is_suppressed(const char *object, const char *interface, cons
  */
 int df_fuzz(GDBusConnection *dcon, const char *name, const char *object, const char *interface)
 {
-        _cleanup_(g_dbus_proxy_unrefp) GDBusProxy *dproxy = NULL;
-        _cleanup_(g_dbus_node_info_unrefp) GDBusNodeInfo *node_info = NULL;
+        g_autoptr(GDBusProxy) dproxy = NULL;
+        g_autoptr(GDBusNodeInfo) node_info = NULL;
         GDBusInterfaceInfo *interface_info = NULL;
         guint64 iterations;
         int method_found = 0, property_found = 0, ret;
@@ -600,8 +600,8 @@ int df_is_valid_dbus(const char *name, const char *obj, const char *intf)
  */
 int df_get_pid(GDBusConnection *dcon, gboolean activate)
 {
-        _cleanup_(g_dbus_proxy_unrefp) GDBusProxy *pproxy = NULL;
-        _cleanup_(g_variant_unrefp) GVariant *variant_pid = NULL;
+        g_autoptr(GDBusProxy) pproxy = NULL;
+        g_autoptr(GVariant) variant_pid = NULL;
         int pid = -1;
 
         pproxy = df_bus_new(dcon,
@@ -621,8 +621,8 @@ int df_get_pid(GDBusConnection *dcon, gboolean activate)
          *  - https://dbus.freedesktop.org/doc/system-activation.txt
          */
         if (activate) {
-                _cleanup_(g_error_freep) GError *act_error = NULL;
-                _cleanup_(g_variant_unrefp) GVariant *act_res = NULL;
+                g_autoptr(GError) act_error = NULL;
+                g_autoptr(GVariant) act_res = NULL;
 
                 act_res = df_bus_call_full(pproxy,
                                            "StartServiceByName",
@@ -954,8 +954,8 @@ void df_parse_parameters(int argc, char **argv)
  */
 int df_load_suppressions(void)
 {
-        _cleanup_fclose_ FILE *f = NULL;
-        _cleanup_free_ char *line = NULL, *home_supp = NULL;
+        g_autoptr(FILE) f = NULL;
+        g_autoptr(char) line = NULL, home_supp = NULL;
         char *env = NULL;
         int name_found = 0, i = 0;
         size_t len = 0;
@@ -1012,7 +1012,7 @@ int df_load_suppressions(void)
 
         i = 0;
         while (i < (MAXLEN - 1) && (n = getline(&line, &len, f)) > 0) {
-                _cleanup_free_ char *suppression = NULL, *description = NULL;
+                g_autoptr(char) suppression = NULL, description = NULL;
                 char *p;
 
                 if (line[0] == '[')

--- a/src/fuzz.c
+++ b/src/fuzz.c
@@ -350,7 +350,7 @@ static int df_exec_cmd_check(const char *cmd)
                 return 0;
 
         const char *fn = "/dev/null";
-        _cleanup_(closep) int stdoutcpy = -1, stderrcpy = -1, fd = -1;
+        g_auto(fd_t) stdoutcpy = -1, stderrcpy = -1, fd = -1;
         int status = 0;
 
         fd = open(fn, O_RDWR, S_IRUSR | S_IWUSR);

--- a/src/fuzz.h
+++ b/src/fuzz.h
@@ -28,34 +28,37 @@
   * testing continues with a next method */
 #define MAX_EXCEPTIONS 50
 
-struct df_dbus_method {
+typedef struct df_dbus_method {
         char *name;
         char *signature;
         gboolean returns_value;
         gboolean expect_reply;
-};
+} df_dbus_method_t;
 
-static inline void df_dbus_method_cleanup(struct df_dbus_method *p)
+static inline void df_dbus_method_clear(df_dbus_method_t *p)
 {
         free(p->name);
         free(p->signature);
         memset(p, 0, sizeof(*p));
 }
 
-struct df_dbus_property {
+typedef struct df_dbus_property {
         char *name;
         char *signature;
         gboolean is_readable;
         gboolean is_writable;
         gboolean expect_reply;
-};
+} df_dbus_property_t;
 
-static inline void df_dbus_property_cleanup(struct df_dbus_property *p)
+static inline void df_dbus_property_clear(df_dbus_property_t *p)
 {
         free(p->name);
         free(p->signature);
         memset(p, 0, sizeof(*p));
 }
+
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(df_dbus_method_t, df_dbus_method_clear)
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(df_dbus_property_t, df_dbus_property_clear)
 
 guint64 df_get_number_of_iterations(const char *signature);
 GVariant *df_generate_random_basic(const GVariantType *type, guint64 iteration);

--- a/src/introspection.c
+++ b/src/introspection.c
@@ -30,9 +30,9 @@
 
 GDBusNodeInfo *df_get_interface_info(GDBusProxy *dproxy, const char *interface, GDBusInterfaceInfo **ret_iinfo)
 {
-        _cleanup_(g_error_freep) GError *error = NULL;
-        _cleanup_(g_freep) gchar *introspection_xml = NULL;
-        _cleanup_(g_variant_unrefp) GVariant *response = NULL;
+        g_autoptr(GError) error = NULL;
+        g_autoptr(gchar) introspection_xml = NULL;
+        g_autoptr(GVariant) response = NULL;
         GDBusNodeInfo *introspection_data = NULL;
         GDBusInterfaceInfo *interface_info = NULL;
 

--- a/src/rand.c
+++ b/src/rand.c
@@ -48,8 +48,8 @@ void df_rand_init()
 
 int df_rand_load_external_dictionary(const char *filename)
 {
-        _cleanup_fclose_ FILE *f = NULL;
-        _cleanup_free_ char *line = NULL;
+        g_autoptr(FILE) f = NULL;
+        g_autoptr(char) line = NULL;
         char **array = NULL;
         size_t allocated = 0, len = 0, i = 0;
         ssize_t n;
@@ -320,7 +320,7 @@ int df_rand_string(gchar **buf, guint64 iteration)
                 "Description",
                 "127.0.0.1",
         };
-        _cleanup_(g_freep) gchar *ret = NULL;
+        g_autoptr(gchar) ret = NULL;
         size_t len;
 
         /* If -f/--string-file= was used, use the loaded strings instead of the
@@ -376,7 +376,7 @@ int df_rand_dbus_objpath_string(gchar **buf, guint64 iteration)
                 "/0/0/0",
                 "/_/_/_",
         };
-        _cleanup_(g_freep) gchar *ret = NULL;
+        g_autoptr(gchar) ret = NULL;
         guint16 size;
         int i, j, beg;
 
@@ -441,7 +441,7 @@ int df_rand_dbus_signature_string(gchar **buf, guint64 iteration)
 {
         /* TODO: support arrays ('a') and other complex types */
         static const char valid_signature_chars[] = "ybnqiuxtdsogvh";
-        _cleanup_(g_freep) gchar *ret = NULL;
+        g_autoptr(gchar) ret = NULL;
         uint16_t size, i = 0;
 
         size = (iteration % MAXSIG) + 1;
@@ -468,7 +468,7 @@ int df_rand_dbus_signature_string(gchar **buf, guint64 iteration)
  */
 int df_rand_GVariant(GVariant **var, guint64 iteration)
 {
-        _cleanup_(g_freep) gchar *str = NULL;
+        g_autoptr(gchar) str = NULL;
         int r;
 
         r = df_rand_string(&str, iteration);

--- a/src/rand.c
+++ b/src/rand.c
@@ -73,10 +73,10 @@ int df_rand_load_external_dictionary(const char *filename)
                 if (line[n - 1] == '\n')
                         line[n - 1] = 0;
 
-                array[i++] = TAKE_PTR(line);
+                array[i++] = g_steal_pointer(&line);
         }
 
-        df_external_dictionary.strings = TAKE_PTR(array);
+        df_external_dictionary.strings = g_steal_pointer(&array);
         df_external_dictionary.size = i;
 
         return 0;
@@ -347,7 +347,7 @@ int df_rand_string(gchar **buf, guint64 iteration)
                 df_rand_random_string(ret, len);
         }
 
-        *buf = TAKE_PTR(ret);
+        *buf = g_steal_pointer(&ret);
 
         return 0;
 }
@@ -420,7 +420,7 @@ int df_rand_dbus_objpath_string(gchar **buf, guint64 iteration)
                 ret[j] = '\0';
         }
 
-        *buf = TAKE_PTR(ret);
+        *buf = g_steal_pointer(&ret);
 
         return 0;
 }
@@ -454,7 +454,7 @@ int df_rand_dbus_signature_string(gchar **buf, guint64 iteration)
                 ret[i] = valid_signature_chars[rand() % G_N_ELEMENTS(valid_signature_chars)];
 
         ret[i] = '\0';
-        *buf = TAKE_PTR(ret);
+        *buf = g_steal_pointer(&ret);
 
         return 0;
 }

--- a/src/util.h
+++ b/src/util.h
@@ -5,7 +5,7 @@
 
 typedef int fd_t;
 
-static inline int safe_close(int fd) {
+static inline int safe_close(fd_t fd) {
         if (fd >= 0)
                 close(fd);
 
@@ -54,16 +54,6 @@ static inline int isempty(const char *s) {
         ({                                      \
                 free(memory);                   \
                 (typeof(memory)) NULL;          \
-        })
-
-/* Takes inspiration from Rust's Option::take() method: reads and returns a pointer, but at the same time
- * resets it to NULL. See: https://doc.rust-lang.org/std/option/enum.Option.html#method.take */
-#define TAKE_PTR(ptr)                           \
-        ({                                      \
-                typeof(ptr) *_pptr_ = &(ptr);   \
-                typeof(ptr) _ptr_ = *_pptr_;    \
-                *_pptr_ = NULL;                 \
-                _ptr_;                          \
         })
 
 /* Returns the number of chars needed to format variables of the

--- a/src/util.h
+++ b/src/util.h
@@ -3,30 +3,6 @@
 
 #define USEC_PER_SEC ((useconds_t) 1000000ULL)
 
-/* When func() returns the void value (NULL, -1, …) of the appropriate type */
-#define DEFINE_TRIVIAL_CLEANUP_FUNC(type, func)                 \
-        static inline void func##p(type *p) {                   \
-                if (*p)                                         \
-                        *p = func(*p);                          \
-        }
-
-/* When func() doesn't return the appropriate type, set variable to empty afterwards */
-#define DEFINE_TRIVIAL_CLEANUP_FUNC_FULL(type, func, empty)     \
-        static inline void func##p(type *p) {                   \
-                if (*p != (empty)) {                            \
-                        func(*p);                               \
-                        *p = (empty);                           \
-                }                                               \
-        }
-
-static inline void g_dbus_connection_unref(GDBusConnection *p) {
-        g_object_unref(p);
-}
-
-static inline void g_dbus_proxy_unref(GDBusProxy *p) {
-        g_object_unref(p);
-}
-
 static inline int safe_close(int fd) {
         if (fd >= 0)
                 close(fd);
@@ -43,10 +19,6 @@ static inline FILE *safe_fclose(FILE *f) {
                 fclose(f);
 
         return NULL;
-}
-
-static inline void fclosep(FILE **f) {
-        safe_fclose(*f);
 }
 
 static inline GVariant *safe_g_variant_unref(GVariant *p) {
@@ -70,21 +42,13 @@ static inline GDBusProxy *safe_g_dbus_proxy_unref(GDBusProxy *p) {
         return NULL;
 }
 
-DEFINE_TRIVIAL_CLEANUP_FUNC_FULL(char*, free, NULL);
-DEFINE_TRIVIAL_CLEANUP_FUNC_FULL(gchar*, g_free, NULL);
-DEFINE_TRIVIAL_CLEANUP_FUNC_FULL(GDBusConnection*, g_dbus_connection_unref, NULL);
-DEFINE_TRIVIAL_CLEANUP_FUNC_FULL(GDBusProxy*, g_dbus_proxy_unref, NULL);
-DEFINE_TRIVIAL_CLEANUP_FUNC_FULL(GVariantIter*, g_variant_iter_free, NULL);
-DEFINE_TRIVIAL_CLEANUP_FUNC_FULL(GError*, g_error_free, NULL);
-DEFINE_TRIVIAL_CLEANUP_FUNC_FULL(GVariant*, g_variant_unref, NULL);
-DEFINE_TRIVIAL_CLEANUP_FUNC_FULL(GVariantBuilder*, g_variant_builder_unref, NULL);
-DEFINE_TRIVIAL_CLEANUP_FUNC_FULL(GVariantType*, g_variant_type_free, NULL);
-DEFINE_TRIVIAL_CLEANUP_FUNC_FULL(GDBusNodeInfo*, g_dbus_node_info_unref, NULL);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(FILE, safe_fclose)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(char, free)
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(gchar, g_free)
 
 #define _cleanup_(x) __attribute__((__cleanup__(x)))
-#define _cleanup_free_ _cleanup_(freep)
 #define _cleanup_close_ _cleanup_(closep)
-#define _cleanup_fclose_ _cleanup_(fclosep)
 
 static inline int isempty(const char *s) {
         return !s || s[0] == '\0';

--- a/src/util.h
+++ b/src/util.h
@@ -3,15 +3,13 @@
 
 #define USEC_PER_SEC ((useconds_t) 1000000ULL)
 
+typedef int fd_t;
+
 static inline int safe_close(int fd) {
         if (fd >= 0)
                 close(fd);
 
         return -1;
-}
-
-static inline void closep(int *fd) {
-        safe_close(*fd);
 }
 
 static inline FILE *safe_fclose(FILE *f) {
@@ -42,13 +40,11 @@ static inline GDBusProxy *safe_g_dbus_proxy_unref(GDBusProxy *p) {
         return NULL;
 }
 
-
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(FILE, safe_fclose)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(char, free)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(gchar, g_free)
 
-#define _cleanup_(x) __attribute__((__cleanup__(x)))
-#define _cleanup_close_ _cleanup_(closep)
+G_DEFINE_AUTO_CLEANUP_FREE_FUNC(fd_t, safe_close, -1)
 
 static inline int isempty(const char *s) {
         return !s || s[0] == '\0';


### PR DESCRIPTION
GLib already implements a lot of helpers I brought over from systemd, so let's use them to make the code base shorter and more unified.