### PR TITLE
dfuzzer.conf: suppress BecomeMonitor

### DIFF
--- a/src/dfuzzer.conf
+++ b/src/dfuzzer.conf
@@ -104,3 +104,6 @@ Authenticate expected high memory consumption (BZ#1022530)
 
 [org.freedesktop.dfuzzerServer]
 df_hang Intentionally hangs the server to test timeout handling
+
+[org.freedesktop.DBus]
+org.freedesktop.DBus.Monitoring:BecomeMonitor prevents dfuzzer from sending messages


### PR DESCRIPTION
Once this method is called dfuzzer can no longer send messages and
bails out with
```
  PASS [M] Introspect
 Interface: org.freedesktop.DBus.Monitoring
  PASS [M] BecomeMonitor
 Interface: org.freedesktop.DBus.Peer
Error: Unable to create proxy for bus name 'org.freedesktop.DBus'.
Exit status: 1
```

https://dbus.freedesktop.org/doc/dbus-specification.html#bus-messages-become-monitor