### PR TITLE
fuzz: drop leftover debug printf()

### DIFF
--- a/src/fuzz.c
+++ b/src/fuzz.c
@@ -626,8 +626,6 @@ static int df_fuzz_get_property(GDBusProxy *pproxy, const char *interface,
 {
         g_autoptr(GVariant) response = NULL;
 
-        printf("INTERFACE: %s\nPROPERTY: %s\n", interface, property->name);
-
         response = df_bus_call(pproxy, "Get",
                                g_variant_new("(ss)", interface, property->name),
                                G_DBUS_CALL_FLAGS_NONE);


### PR DESCRIPTION
Which got accidentally introduced in ae01b1b67a6744efc5bb0c75a4986792faf6a4ad.