### PR TITLE
fuzz: handle timeouts for Get() on properties gracefully

### DIFF
--- a/src/dfuzzer-test-server.c
+++ b/src/dfuzzer-test-server.c
@@ -99,6 +99,7 @@ static const gchar introspection_xml[] =
 "               <property name='crash_on_write' type='i' access='write'/>"
 "               <property name='crash_on_read' type='a(gov)' access='read'/>"
 "               <property name='read_write' type='(iu)' access='readwrite'/>"
+"               <property name='read_write_timeout' type='u' access='readwrite'/>"
 "       </interface>"
 "</node>";
 
@@ -187,6 +188,8 @@ static GVariant *handle_get_property(
                 test_abort();
         else if (g_str_equal(property_name, "read_write"))
                 response = g_variant_new("(iu)", prop_read_write.i, prop_read_write.u);
+        else if (g_str_equal(property_name, "read_write_timeout"))
+                *error = g_dbus_error_new_for_dbus_error("org.freedesktop.DBus.Error.Timeout", "org.freedesktop.DBus.Error.Timeout");
 
         return response;
 }
@@ -214,7 +217,8 @@ static gboolean handle_set_property(
         else if (g_str_equal(property_name, "read_write")) {
                 g_variant_get(value, "(iu)", &prop_read_write.i, &prop_read_write.u);
                 return TRUE;
-        }
+        } else if (g_str_equal(property_name, "read_write_timeout"))
+                *error = g_dbus_error_new_for_dbus_error("org.freedesktop.DBus.Error.Timeout", "org.freedesktop.DBus.Error.Timeout");
 
         return FALSE;
 }


### PR DESCRIPTION
When trying to run dfuzzer on systemd in CI (with sanitizers), I noticed
frequent fails all with the same root cause:

```
[ 1287.173754] testsuite-21.sh[871]:   FAIL [P] FragmentPath - unexpected response while reading a property
[ 1287.177671] testsuite-21.sh[871]: [RE-CONNECTED TO PID: 1]
[ 1287.181714] testsuite-21.sh[871]: Error while calling method 'Get': Timeout was reached
[ 1287.183605] testsuite-21.sh[871]:   FAIL [P] SourcePath - unexpected response while reading a property
[ 1287.187557] testsuite-21.sh[871]: [RE-CONNECTED TO PID: 1]
[ 1287.191469] testsuite-21.sh[871]: Error while calling method 'Get': Timeout was reached
[ 1287.195521] testsuite-21.sh[871]:   FAIL [P] DropInPaths - unexpected response while reading a property
[ 1287.197451] testsuite-21.sh[871]: [RE-CONNECTED TO PID: 1]
[ 1287.201443] testsuite-21.sh[871]: Error while calling method 'Get': Timeout was reached
[ 1287.205393] testsuite-21.sh[871]:   FAIL [P] UnitFileState - unexpected response while reading a property
[ 1287.207296] testsuite-21.sh[871]: [RE-CONNECTED TO PID: 1]
```

```
[  906.205285] testsuite-21.sh[903]:  Interface: org.freedesktop.systemd1.Unit
[  982.035219] testsuite-21.sh[903]: Error while calling method 'Get': Timeout was reached
[  982.035219] testsuite-21.sh[903]:   FAIL [P] RequiresMountsFor - unexpected response while reading a property
[ 1076.442188] testsuite-21.sh[903]: Error: Unable to create proxy for bus name 'org.freedesktop.DBus'.
[ 1076.442188] testsuite-21.sh[903]: Exit status: 1
```

```
[ 1008.512961] testsuite-21.sh[903]:   PASS [P] ReloadResult (read)
[ 1008.513276] testsuite-21.sh[903]:   [P] CleanResult (read)...Error while calling method 'Get': Timeout was reached
[ 1008.513449] testsuite-21.sh[903]:   FAIL [P] CleanResult - unexpected response while reading a property
[ 1008.513618] testsuite-21.sh[903]: Error: Unable to create proxy for bus name 'org.freedesktop.systemd1'.
[ 1008.513800] testsuite-21.sh[903]: Exit status: 1
```

If my assumptions are correct, this should get resolved once we handle
timeouts for the Get() method for properties in the same way as we already
do it for Set().