### PR TITLE
rand: don't randomly truncate the pseudo-random signatures

### DIFF
--- a/src/rand.c
+++ b/src/rand.c
@@ -451,7 +451,7 @@ int df_rand_dbus_signature_string(gchar **buf, guint64 iteration)
                 return df_fail_ret(-1, "Could not allocate memory for the random string\n");
 
         for (i = 0; i < size; i++)
-                ret[i] = valid_signature_chars[rand() % G_N_ELEMENTS(valid_signature_chars)];
+                ret[i] = valid_signature_chars[rand() % strlen(valid_signature_chars)];
 
         ret[i] = '\0';
         *buf = g_steal_pointer(&ret);


### PR DESCRIPTION
G_N_ELEMENTS() returns the length of the array including the NUL
byte, which means we'd randomly terminate the signature while
generating it, making it way shorter than it should be.

---

I'm working on making the signature generation *generic* to generate arbitrary signatures, but in the meantime let's fix at least this bug I noticed along the way.