### PR TITLE
rand: loosen the rules for the pseudo-random object paths

### DIFF
--- a/src/rand.h
+++ b/src/rand.h
@@ -34,6 +34,10 @@
 /** Maximum length of D-Bus signature string */
 #define MAXSIG 255
 
+#define OBJECT_PATH_VALID_CHARS "ABCDEFGHIJKLMNOPQRSTUVWXYZ" \
+                                "abcdefghijklmnopqrstuvwxyz" \
+                                "0123456789_"
+
 struct external_dictionary {
         size_t size;
         char **strings;


### PR DESCRIPTION
and simplify the code a bit.

According to the D-Bus spec, the object path might be of arbitrary
length, can contain arbitrary amount of elements (but at least one), and
can begin with any of the allowed characters.