### PR TITLE
tree-wide: move logging stuff into a separate file

### DIFF
--- a/src/bus.c
+++ b/src/bus.c
@@ -3,6 +3,7 @@
 
 #include "bus.h"
 #include "dfuzzer.h"
+#include "log.h"
 #include "util.h"
 
 GDBusProxy *df_bus_new_full(GDBusConnection *dcon, const char *name, const char *object,

--- a/src/dfuzzer.h
+++ b/src/dfuzzer.h
@@ -24,6 +24,8 @@
 #include <errno.h>
 #include <unistd.h>
 
+#include "log.h"
+
 #define DF_BUS_ROOT_NODE "/"
 
 enum {
@@ -55,8 +57,6 @@ struct suppression_item {
 
 /* Shared global variables */
 extern guint64 df_buf_size;
-extern int df_verbose_flag;
-extern int df_debug_flag;
 
 /* Public functions */
 
@@ -172,38 +172,3 @@ int df_load_suppressions(void);
  * @param name Name of program
  */
 void df_print_help(const char *name);
-
-/**
- * @function Displays an error message.
- * @param message Error message which will be printed
- * @param error Pointer on GError structure containing error specification
- */
-void df_error(const char *message, GError *error);
-
-/**
- * @function Prints debug message.
- * @param format Format string
- */
-void df_debug(const char *format, ...) __attribute__((__format__(printf, 1, 2)));
-
-/**
- * @function Prints verbose message.
- * @param format Format string
- */
-void df_verbose(const char *format, ...) __attribute__((__format__(printf, 1, 2)));
-
-/**
- * @function Prints error message.
- * @param format Format string
- */
-void df_fail(const char *format, ...) __attribute__((__format__(printf, 1, 2)));
-
-#define df_log_ret_internal(ret, fun, ...)          \
-        ({                                          \
-                fun(__VA_ARGS__);                   \
-                ret;                                \
-        })
-
-#define df_oom(void) df_log_ret_internal(-ENOMEM, df_fail, "Allocation error: %m\n")
-#define df_fail_ret(ret, ...) df_log_ret_internal(ret, df_fail, __VA_ARGS__)
-#define df_debug_ret(ret, ...) df_log_ret_internal(ret, df_debug, __VA_ARGS__)

--- a/src/fuzz.h
+++ b/src/fuzz.h
@@ -129,9 +129,3 @@ int df_fuzz_test_method(
 int df_fuzz_test_property(GDBusConnection *dcon, const struct df_dbus_property *property,
                           const char *bus, const char *object, const char *interface,
                           const int pid, guint64 iterations);
-extern FILE* logfile;
-
-/** Writes a message to a logfile if it is opened (i.e. if -L flag was passed
- * when running dfuzzer.
- */
-#define FULL_LOG(fmt, ...) if(logfile) fprintf(logfile, fmt, ##__VA_ARGS__)

--- a/src/log.c
+++ b/src/log.c
@@ -1,0 +1,66 @@
+#include <stdio.h>
+
+#include "log.h"
+
+static guint8 log_level_max = DF_LOG_LEVEL_INFO;
+static FILE *log_file;
+
+void df_set_log_level(guint8 log_level)
+{
+        g_assert(log_level < _DF_LOG_LEVEL_MAX);
+
+        log_level_max = log_level;
+}
+
+guint8 df_get_log_level(void)
+{
+        return log_level_max;
+}
+
+int df_log_open_log_file(const char *file_name)
+{
+        g_assert(!log_file);
+
+        log_file = fopen(file_name, "a+");
+        if (!log_file)
+                return df_fail_ret(-1, "Failed to open file %s: %m\n", file_name);
+
+        return 0;
+}
+
+gboolean df_log_file_is_open(void)
+{
+        return !!log_file;
+}
+
+void df_log_file(const char *format, ...)
+{
+        if (log_file) {
+                va_list args;
+
+                va_start(args, format);
+                vfprintf(log_file, format, args);
+                va_end(args);
+        }
+}
+
+void df_log_full(gint8 log_level, FILE *target, const char *format, ...)
+{
+        if (log_level > log_level_max)
+                return;
+
+        va_list args;
+
+        va_start(args, format);
+        vfprintf(target, format, args);
+        va_end(args);
+        fflush(target);
+}
+
+void df_error(const char *message, GError *error)
+{
+        if (log_level_max < DF_LOG_LEVEL_DEBUG)
+                return;
+
+        fprintf(stderr, "%s: %s\n", message, error->message ?: "n/a");
+}

--- a/src/log.h
+++ b/src/log.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <glib.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+enum {
+        DF_LOG_LEVEL_INFO = 0,
+        DF_LOG_LEVEL_VERBOSE,
+        DF_LOG_LEVEL_DEBUG,
+        _DF_LOG_LEVEL_MAX
+};
+
+void df_set_log_level(guint8 log_level);
+guint8 df_get_log_level(void);
+int df_log_open_log_file(const char *file_name);
+gboolean df_log_file_is_open(void);
+
+/* Normal logging */
+void df_log_file(const char *format, ...) __attribute__((__format__(printf, 1, 2)));
+void df_log_full(gint8 log_level, FILE *target, const char *format, ...) __attribute__((__format__(printf, 3, 4)));
+
+#define df_log(...)         df_log_full(DF_LOG_LEVEL_INFO, stdout, __VA_ARGS__)
+#define df_fail(...)        df_log_full(DF_LOG_LEVEL_INFO, stderr,  __VA_ARGS__)
+#define df_verbose(...)     df_log_full(DF_LOG_LEVEL_VERBOSE, stdout, __VA_ARGS__)
+#define df_debug(...)       df_log_full(DF_LOG_LEVEL_DEBUG, stdout, __VA_ARGS__)
+
+void df_error(const char *message, GError *error);
+
+/* Logging functions which return a value (i.e. can be used as part of a return statement) */
+#define df_log_ret_internal(ret, fun, ...)          \
+        ({                                          \
+                fun(__VA_ARGS__);                   \
+                ret;                                \
+        })
+
+#define df_oom(void)            df_log_ret_internal(-ENOMEM, df_fail, "Allocation error: %m\n")
+#define df_fail_ret(ret, ...)   df_log_ret_internal(ret, df_fail, __VA_ARGS__)
+#define df_debug_ret(ret, ...)  df_log_ret_internal(ret, df_debug, __VA_ARGS__)

--- a/src/meson.build
+++ b/src/meson.build
@@ -7,6 +7,8 @@ dfuzzer_sources = files(
         'fuzz.h',
         'introspection.c',
         'introspection.h',
+        'log.c',
+        'log.h',
         'rand.c',
         'rand.h',
         'util.c',


### PR DESCRIPTION
Decouple the logging stuff from the main dfuzzer file and simplify it a
bit.

This is the first of several necessary steps to allow introducing unit
tests for dfuzzer's internal functions.