### PR TITLE
fuzz: rework df_exec_cmd_check()

### DIFF
--- a/man/dfuzzer.xml
+++ b/man/dfuzzer.xml
@@ -118,6 +118,13 @@
             </varlistentry>
 
             <varlistentry>
+                <term><option>--show-command-output</option></term>
+
+                <listitem><para>Don't suppress stdout/stderr of a <replaceable>COMMAND</replaceable>
+                specified via <option>--command=</option></para></listitem>
+            </varlistentry>
+
+            <varlistentry>
                 <term><option>-f <replaceable>FILENAME</replaceable></option></term>
                 <term><option>--dictionary=<replaceable>FILENAME</replaceable></option></term>
 

--- a/src/dfuzzer.c
+++ b/src/dfuzzer.c
@@ -597,6 +597,7 @@ static void df_print_help(const char *name)
          "  -I --iterations=ITER        Set both the minimum and maximum number of iterations to ITER\n"
          "                              See --max-iterations= and --min-iterations= above\n"
          "  -e --command=COMMAND        Command/script to execute after each method call.\n"
+         "     --show-command-output    Don't suppress stdout/stderr of a COMMAND.\n"
          "  -f --dictionary=FILENAME    Name of a file with custom dictionary which is used as input\n"
          "                              for fuzzed methods before generating random data.\n"
          "\nExamples:\n\n"
@@ -622,30 +623,32 @@ static void df_parse_parameters(int argc, char **argv)
                  * short variant */
                 ARG_SKIP_METHODS = 0x100,
                 ARG_SKIP_PROPERTIES,
+                ARG_SHOW_COMMAND_OUTPUT
         };
 
         static const struct option options[] = {
-                { "buffer-limit",       required_argument,  NULL,   'b'                 },
-                { "debug",              no_argument,        NULL,   'd'                 },
-                { "command",            required_argument,  NULL,   'e'                 },
-                { "string-file",        required_argument,  NULL,   'f'                 },
-                { "help",               no_argument,        NULL,   'h'                 },
-                { "interface",          required_argument,  NULL,   'i'                 },
-                { "list",               no_argument,        NULL,   'l'                 },
-                { "mem-limit",          required_argument,  NULL,   'm'                 },
-                { "bus",                required_argument,  NULL,   'n'                 },
-                { "object",             required_argument,  NULL,   'o'                 },
-                { "property",           required_argument,  NULL,   'p'                 },
-                { "no-suppressions",    no_argument,        NULL,   's'                 },
-                { "method",             required_argument,  NULL,   't'                 },
-                { "verbose",            no_argument,        NULL,   'v'                 },
-                { "log-dir",            required_argument,  NULL,   'L'                 },
-                { "version",            no_argument,        NULL,   'V'                 },
-                { "max-iterations",     required_argument,  NULL,   'x'                 },
-                { "min-iterations",     required_argument,  NULL,   'y'                 },
-                { "iterations",         required_argument,  NULL,   'I'                 },
-                { "skip-methods",       no_argument,        NULL,   ARG_SKIP_METHODS    },
-                { "skip-properties",    no_argument,        NULL,   ARG_SKIP_PROPERTIES },
+                { "buffer-limit",        required_argument,  NULL,   'b'                     },
+                { "debug",               no_argument,        NULL,   'd'                     },
+                { "command",             required_argument,  NULL,   'e'                     },
+                { "string-file",         required_argument,  NULL,   'f'                     },
+                { "help",                no_argument,        NULL,   'h'                     },
+                { "interface",           required_argument,  NULL,   'i'                     },
+                { "list",                no_argument,        NULL,   'l'                     },
+                { "mem-limit",           required_argument,  NULL,   'm'                     },
+                { "bus",                 required_argument,  NULL,   'n'                     },
+                { "object",              required_argument,  NULL,   'o'                     },
+                { "property",            required_argument,  NULL,   'p'                     },
+                { "no-suppressions",     no_argument,        NULL,   's'                     },
+                { "method",              required_argument,  NULL,   't'                     },
+                { "verbose",             no_argument,        NULL,   'v'                     },
+                { "log-dir",             required_argument,  NULL,   'L'                     },
+                { "version",             no_argument,        NULL,   'V'                     },
+                { "max-iterations",      required_argument,  NULL,   'x'                     },
+                { "min-iterations",      required_argument,  NULL,   'y'                     },
+                { "iterations",          required_argument,  NULL,   'I'                     },
+                { "skip-methods",        no_argument,        NULL,   ARG_SKIP_METHODS        },
+                { "skip-properties",     no_argument,        NULL,   ARG_SKIP_PROPERTIES     },
+                { "show-command-output", no_argument,        NULL,   ARG_SHOW_COMMAND_OUTPUT },
                 {}
         };
 
@@ -794,6 +797,9 @@ static void df_parse_parameters(int argc, char **argv)
                                 break;
                         case ARG_SKIP_PROPERTIES:
                                 df_skip_properties = TRUE;
+                                break;
+                        case ARG_SHOW_COMMAND_OUTPUT:
+                                df_fuzz_set_show_command_output(TRUE);
                                 break;
                         default:    // '?'
                                 exit(1);

--- a/src/fuzz.h
+++ b/src/fuzz.h
@@ -75,6 +75,7 @@ G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(df_dbus_property_t, df_dbus_property_clear)
 
 void df_fuzz_set_buffer_length(const guint64 length);
 guint64 df_fuzz_get_buffer_length(void);
+void df_fuzz_set_show_command_output(gboolean value);
 
 guint64 df_get_number_of_iterations(const char *signature);
 /**

--- a/src/util.h
+++ b/src/util.h
@@ -128,3 +128,5 @@ DEFINE_ANSI_FUNC(cyan,       CYAN);
 DEFINE_ANSI_FUNC(normal,     NORMAL);
 DEFINE_ANSI_FUNC(bold,       BOLD);
 DEFINE_ANSI_FUNC(cr,         CR);
+
+int df_execute_external_command(const char *command, gboolean show_output);

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,5 +1,6 @@
 tests += [
         [files('test-rand.c')],
+        [files('test-util.c')],
 ]
 
 # vi: sw=8 ts=8 et:

--- a/test/test-util.c
+++ b/test/test-util.c
@@ -1,0 +1,30 @@
+#include <gio/gio.h>
+#include <glib.h>
+#include <stdio.h>
+
+#include "util.h"
+#include "log.h"
+
+static void test_df_execute_external_command(void)
+{
+        for (guint8 i = 0; i < 2; i++) {
+                gboolean show_output = i == 0 ? FALSE : TRUE;
+                g_test_message("show_output: %s", show_output ? "TRUE" : "FALSE");
+
+                g_assert_true(df_execute_external_command("true", show_output) == 0);
+                g_assert_true(df_execute_external_command("true; echo hello world; cat /proc/$$/stat", show_output) == 0);
+                g_assert_true(df_execute_external_command("true; echo hello world; false /proc/$$/stat", show_output) > 0);
+                g_assert_true(df_execute_external_command("exit 66", show_output) == 66);
+                g_assert_true(df_execute_external_command("this-should-not-exist", show_output) > 0);
+                g_assert_true(df_execute_external_command("kill -SEGV $$", show_output) > 0);
+        }
+}
+
+int main(int argc, char *argv[])
+{
+        g_test_init(&argc, &argv, NULL);
+
+        g_test_add_func("/df_util/df_execute_external_command", test_df_execute_external_command);
+
+        return g_test_run();
+}


### PR DESCRIPTION
Explicitly use fork() & execl() to avoid the file descriptor
shenanigans, and move & rename the function to util.[ch].

Also, when at it, add a unit test for the function as well.
