### PR TITLE
tree-wide: unify asserts

### DIFF
--- a/src/dfuzzer.c
+++ b/src/dfuzzer.c
@@ -19,7 +19,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <assert.h>
 #include <gio/gio.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/fuzz.c
+++ b/src/fuzz.c
@@ -18,7 +18,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <assert.h>
 #include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -61,6 +60,8 @@ guint64 df_get_number_of_iterations(const char *signature)
 {
         guint64 iterations = 0;
         guint32 multiplier = 1, current_nest_level = 0;
+
+        g_assert(signature);
 
         for (size_t i = 0; i < strlen(signature); i++) {
                 switch (signature[i]) {
@@ -133,10 +134,8 @@ guint64 df_get_number_of_iterations(const char *signature)
 
 int df_fuzz_init(GDBusProxy *dproxy)
 {
-        if (dproxy == NULL) {
-                df_debug("Passing NULL argument to function.\n");
-                return -1;
-        }
+        g_assert(dproxy);
+
         df_dproxy = dproxy;
 
         return 0;
@@ -150,8 +149,8 @@ static void df_fuzz_write_log(const struct df_dbus_method *method, GVariant *val
 {
         g_autoptr(char) variant_value = NULL;
 
-        assert(method);
-        assert(value);
+        g_assert(method);
+        g_assert(value);
 
         df_log_file("%s;", method->name);
 
@@ -230,7 +229,7 @@ static int df_check_if_exited(const int pid) {
         size_t len = 0;
         int dumping;
 
-        assert(pid > 0);
+        g_assert(pid > 0);
 
         sprintf(proc_pid, "/proc/%d/status", pid);
 

--- a/src/introspection.c
+++ b/src/introspection.c
@@ -17,7 +17,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <assert.h>
 #include <gio/gio.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -36,9 +35,9 @@ GDBusNodeInfo *df_get_interface_info(GDBusProxy *dproxy, const char *interface, 
         GDBusNodeInfo *introspection_data = NULL;
         GDBusInterfaceInfo *interface_info = NULL;
 
-        assert(dproxy);
-        assert(interface);
-        assert(ret_iinfo);
+        g_assert(dproxy);
+        g_assert(interface);
+        g_assert(ret_iinfo);
 
         // Synchronously invokes the org.freedesktop.DBus.Introspectable.Introspect
         // method on dproxy to get introspection data in XML format
@@ -82,7 +81,7 @@ char *df_method_get_full_signature(const GDBusMethodInfo *method)
         char *r, *e;
         size_t len = 0;
 
-        assert(method);
+        g_assert(method);
 
         for (GDBusArgInfo **arg = method->in_args; *arg; arg++)
                 len += strlen((*arg)->signature);
@@ -106,7 +105,7 @@ gboolean df_object_returns_reply(GDBusAnnotationInfo **annotations)
 {
         const gchar *annotation_str;
 
-        assert(annotations);
+        g_assert(annotations);
 
         annotation_str = g_dbus_annotation_info_lookup(annotations,
                                                        "org.freedesktop.DBus.Method.NoReply");

--- a/src/rand.c
+++ b/src/rand.c
@@ -17,7 +17,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <assert.h>
 #include <errno.h>
 #include <gio/gio.h>
 #include <glib.h>
@@ -53,7 +52,7 @@ int df_rand_load_external_dictionary(const char *filename)
         size_t allocated = 0, len = 0, i = 0;
         ssize_t n;
 
-        assert(filename);
+        g_assert(filename);
 
         f = fopen(filename, "r");
         if (!f)

--- a/src/util.c
+++ b/src/util.c
@@ -1,6 +1,5 @@
 /** @file util.c */
 
-#include <assert.h>
 #include <errno.h>
 #include <gio/gio.h>
 #include <stdarg.h>
@@ -45,7 +44,7 @@ int safe_strtoull(const gchar *p, guint64 *ret)
         gchar *e = NULL;
         guint32 l;
 
-        assert(ret);
+        g_assert(ret);
 
         errno = 0;
         l = g_ascii_strtoull(p, &e, 10);


### PR DESCRIPTION
Let's use g_assert() everywhere instead of "plain" assert().