### PR TITLE
packit: drop the meson_test related sed

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -20,7 +20,6 @@ actions:
     # Drop the "sources" file so rebase-helper doesn't think we're a dist-git
     - "rm -fv .packit_rpm/sources"
     - sed -i '1 i%define _unpackaged_files_terminate_build 0' .packit_rpm/dfuzzer.spec
-    - sed -i '/^%meson$/a%meson_test' .packit_rpm/dfuzzer.spec
     - sed -i 's/^%meson$/%meson --werror -Ddfuzzer-test-server=true/' .packit_rpm/dfuzzer.spec
 
 jobs:


### PR DESCRIPTION
since the unit tests are now part of the Rawhide spec file.

See: https://src.fedoraproject.org/rpms/dfuzzer/c/dc958e7916ad4db426a79a059947fd72986fc11c?branch=rawhide