### PR TITLE
ci: update Coveralls to v2.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,8 @@ jobs:
           lcov --extract coverage.info.raw "$(pwd)/*" --rc lcov_branch_coverage=1 --output-file coverage.info
 
       - name: Coveralls
-        uses: coverallsapp/github-action@1.1.3
+        uses: coverallsapp/github-action@v2.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./coverage.info
+          file: ./coverage.info
+          format: lcov


### PR DESCRIPTION
This also replaces the deprecated `path-to-lcov` with `file`, and adds a now semi-required `format` parameter [0].

Supersedes: #127

[0] https://github.com/coverallsapp/github-action/blob/release/v2/UPGRADE.md#v1---v2