### PR TITLE
meson: use fs.stem() to get the test name

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -20,6 +20,8 @@ config_h = configure_file(
               output : 'config.h',
               configuration : conf)
 
+fs = import('fs')
+
 add_project_arguments('-include', 'config.h', language : 'c')
 
 subdir('src')
@@ -72,7 +74,7 @@ install_data('src/dfuzzer.conf', install_dir : get_option('sysconfdir'))
 
 foreach tuple : tests
         sources = tuple[0]
-        name = '@0@'.format(sources[0]).split('/')[-1].split('.')[0]
+        name = fs.stem(sources[0])
 
         exe = executable(
                 name,


### PR DESCRIPTION
Apart from looking way nicer, it also gets rid of a deprecation warning with meson >= 1.3.0:
```
...
Configuring config.h using configuration
meson.build:75: DEPRECATION: Project uses feature that was always broken, and is now deprecated since '1.3.0': str.format: Value other than strings, integers, bools, options, dictionaries and lists thereof.. Build targets in project: 3
WARNING: Broken features used:
 * 1.3.0: {'str.format: Value other than strings, integers, bools, options, dictionaries and lists thereof.'}
```
Docs: https://mesonbuild.com/Fs-module.html#stem