### PR TITLE
Fix build with -Werror=calloc-transposed-args

### DIFF
--- a/src/suppression.c
+++ b/src/suppression.c
@@ -120,7 +120,7 @@ int df_suppression_load(GList **suppressions, const char *service_name)
                 if (sscanf(line, "%ms %m[^\n]", &suppression, &description) < 1)
                         return df_fail_ret(-1, "Failed to parse line '%s'\n", line);
 
-                item = calloc(sizeof(*item), 1);
+                item = calloc(1, sizeof(*item));
                 if (!item)
                         return df_oom();
 


### PR DESCRIPTION
[Fix build with -Werror=calloc-transposed-args](https://github.com/dbus-fuzzer/dfuzzer/commit/067939b97b7ed6a7877b6e9b566bc921befa8e23)

calloc() expects the number of elements as the first argument, and the
size of each element as the second one. Recent-enough gcc/clang started
warning about this, so let's fix the order of the arugments to avoid
build errors with -Werror.
```
[9/30] Compiling C object dfuzzer.p/src_suppression.c.o
../src/suppression.c: In function ‘df_suppression_load’:
../src/suppression.c:123:37: warning: ‘calloc’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
  123 |                 item = calloc(sizeof(*item), 1);
      |                                     ^
../src/suppression.c:123:37: note: earlier argument should specify number of elements, later size of each element
```
Resolves https://github.com/dbus-fuzzer/dfuzzer/issues/143